### PR TITLE
ENH: Followup audit of FT build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t"]
         include:
           - os: windows-2019
             python_version: "3.6"

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ cdef class MatrixArray:
         self.length = len(py_matrices)
         self.matrices = <SparseMatrix**>self.mem.alloc(self.length, sizeof(SparseMatrix*))
         for i, py_matrix in enumerate(py_matrices):
-            self.matrices[i] = sparse_matrix_init(self.mem, py_matrix)
+            self.matrices[i] = sparse_matrix_init_cymem(self.mem, py_matrix)
 
 cdef SparseMatrix* sparse_matrix_init_cymem(Pool mem, list py_matrix) except NULL:
     sm = <SparseMatrix*>mem.alloc(1, sizeof(SparseMatrix))

--- a/README.md
+++ b/README.md
@@ -59,18 +59,13 @@ from packaging.version import Version
 
 
 compiler_directives = dict()
-compiler_tenv = dict()
 
 if Version(cython_version) >= Version("3.1.0"):
     compiler_directives["freethreading_compatible"] = True
-    compiler_tenv["CYTHON_FREE_THREADING"] = True
-else:
-    compiler_tenv["CYTHON_FREE_THREADING"] = False
 
 setup(
     ext_modules = cythonize("*.pyx", language_level=3,
-                                  compiler_directives=compiler_directives,
-                                  compile_time_env=compiler_tenv)
+                                  compiler_directives=compiler_directives)
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,13 +59,18 @@ from packaging.version import Version
 
 
 compiler_directives = dict()
+compiler_tenv = dict()
 
 if Version(cython_version) >= Version("3.1.0"):
     compiler_directives["freethreading_compatible"] = True
+    compiler_tenv["CYTHON_FREE_THREADING"] = True
+else:
+    compiler_tenv["CYTHON_FREE_THREADING"] = False
 
 setup(
     ext_modules = cythonize("*.pyx", language_level=3,
-                                  compiler_directives=compiler_directives)
+                                  compiler_directives=compiler_directives,
+                                  compile_time_env=compiler_tenv)
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,32 @@ pip install cymem
 Currently `Pool` is not thread safe when used from multiple threads at once;
 **please avoid sharing a single** `Pool` instance between threads.
 
+Also remember to declare `freethreading_compatible` for the example case below:
+
+``` python
+from setuptools import setup
+from Cython.Build import cythonize
+
+from Cython.Compiler.Version import version as cython_version
+from packaging.version import Version
+
+
+compiler_directives = dict()
+compiler_tenv = dict()
+
+if Version(cython_version) >= Version("3.1.0"):
+    compiler_directives["freethreading_compatible"] = True
+    compiler_tenv["CYTHON_FREE_THREADING"] = True
+else:
+    compiler_tenv["CYTHON_FREE_THREADING"] = False
+
+setup(
+    ext_modules = cythonize("*.pyx", language_level=3,
+                                  compiler_directives=compiler_directives,
+                                  compile_time_env=compiler_tenv)
+)
+```
+
 ## Example Use Case: An array of structs
 
 Let's say we want a sequence of sparse matrices. We need fast access, and a

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ pip install -U pip setuptools wheel
 pip install cymem
 ```
 
+### Free threading
+
+`cymem` has support for being built and run under free-threaded CPython.
+Currently `Pool` is not thread safe when used from multiple threads at once;
+**please avoid sharing a single** `Pool` instance between threads.
+
 ## Example Use Case: An array of structs
 
 Let's say we want a sequence of sparse matrices. We need fast access, and a

--- a/cymem/cymem.pxd
+++ b/cymem/cymem.pxd
@@ -1,4 +1,6 @@
 ctypedef void* (*malloc_t)(size_t n)
+ctypedef void* (*calloc_t)(size_t n)
+ctypedef void* (*realloc_t)(size_t n)
 ctypedef void (*free_t)(void *p)
 
 cdef class PyMalloc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build = "*"
-skip = "pp* cp36* cp37* cp38*"
+skip = "pp* cp36* cp37* cp38* *t*_i686"
 test-skip = ""
-free-threaded-support = false
+enable = ["cpython-freethreading"]
 
 archs = ["native"]
 

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,13 @@ PACKAGES = find_packages()
 MOD_NAMES = ["cymem.cymem"]
 
 compiler_directives = dict()
+compiler_tenv = dict()
 
 if Version(cython_version) >= Version("3.1.0"):
-    compiler_directives["freethreading_compatible"] =  rue
+    compiler_directives["freethreading_compatible"] = True
+    compiler_tenv["CYTHON_FREE_THREADING"] = True
+else:
+    compiler_tenv["CYTHON_FREE_THREADING"] = False
 
 # By subclassing build_extensions we have the actual compiler that will be used which is really known only after finalize_options
 # http://stackoverflow.com/questions/724664/python-distutils-how-to-get-a-compiler-that-is-going-to-be-used
@@ -107,7 +111,8 @@ def setup_package():
             url=about["__uri__"],
             license=about["__license__"],
             ext_modules=cythonize(ext_modules, language_level=3,
-                                  compiler_directives=compiler_directives),
+                                  compiler_directives=compiler_directives,
+                                  compile_time_env=compiler_tenv),
             setup_requires=["cython>=0.25"],
             classifiers=[
                 "Environment :: Console",

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,21 @@ from setuptools import Extension, setup, find_packages
 from setuptools.command.build_ext import build_ext
 from sysconfig import get_path
 from Cython.Build import cythonize
+from Cython.Compiler.Version import version as cython_version
+from packaging.version import Version
 
 
 PACKAGES = find_packages()
 MOD_NAMES = ["cymem.cymem"]
 
+compiler_directives = dict()
+compiler_tenv = dict()
+
+if Version(cython_version) >= Version("3.1.0"):
+    compiler_directives["freethreading_compatible"] = True
+    compiler_tenv["CYTHON_FREE_THREADING"] = True
+else:
+    compiler_tenv["CYTHON_FREE_THREADING"] = False
 
 # By subclassing build_extensions we have the actual compiler that will be used which is really known only after finalize_options
 # http://stackoverflow.com/questions/724664/python-distutils-how-to-get-a-compiler-that-is-going-to-be-used
@@ -100,7 +110,9 @@ def setup_package():
             version=about["__version__"],
             url=about["__uri__"],
             license=about["__license__"],
-            ext_modules=cythonize(ext_modules, language_level=2),
+            ext_modules=cythonize(ext_modules, language_level=3,
+                                  compiler_directives=compiler_directives,
+                                  compile_time_env=compiler_tenv),
             setup_requires=["cython>=0.25"],
             classifiers=[
                 "Environment :: Console",

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,9 @@ PACKAGES = find_packages()
 MOD_NAMES = ["cymem.cymem"]
 
 compiler_directives = dict()
-compiler_tenv = dict()
 
 if Version(cython_version) >= Version("3.1.0"):
-    compiler_directives["freethreading_compatible"] = True
-    compiler_tenv["CYTHON_FREE_THREADING"] = True
-else:
-    compiler_tenv["CYTHON_FREE_THREADING"] = False
+    compiler_directives["freethreading_compatible"] =  rue
 
 # By subclassing build_extensions we have the actual compiler that will be used which is really known only after finalize_options
 # http://stackoverflow.com/questions/724664/python-distutils-how-to-get-a-compiler-that-is-going-to-be-used
@@ -111,8 +107,7 @@ def setup_package():
             url=about["__uri__"],
             license=about["__license__"],
             ext_modules=cythonize(ext_modules, language_level=3,
-                                  compiler_directives=compiler_directives,
-                                  compile_time_env=compiler_tenv),
+                                  compiler_directives=compiler_directives),
             setup_requires=["cython>=0.25"],
             classifiers=[
                 "Environment :: Console",


### PR DESCRIPTION
cc @ngoldbaum

The main changes here are basically due to not trying to mix C allocator and Python memory allocator via `memset` or `memcpy`.

- Switched `Pool.alloc` to use `PyMem_Calloc`, removing `memset`
- Updated `Pool.realloc` to use `PyMem_Realloc`

This PR is a draft until:

[ ] CI for testing and building wheels with Python 3.13t is fully green.
[ ] More static audits of the code