### PR TITLE
Support cymem builds for WoA

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14, ubuntu-24.04-arm]
+        os: [ubuntu-latest, windows-latest, windows-11-arm, macos-13, macos-14, ubuntu-24.04-arm]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, windows-11-arm, macos-latest]
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
           # The 3.9/3.10 arm64 Python binaries that `setup-python` tries to use

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,14 @@ jobs:
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
           # The 3.9/3.10 arm64 Python binaries that `setup-python` tries to use
-          # don't work on macOS 15 anymore, so skip those.
+          # don't work on macOS 15 & windows arm64 anymore, so skip those.
           - os: macos-latest
             python_version: "3.9"
           - os: macos-latest
+            python_version: "3.10"
+          - os: windows-11-arm
+            python_version: "3.9"
+          - os: windows-11-arm
             python_version: "3.10"
     runs-on: ${{ matrix.os }}
 
@@ -42,7 +46,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
-          architecture: x64
+          architecture: ${{ matrix.os == 'windows-11-arm' && 'arm64' || 'x64' }}
 
       - name: Build sdist
         run: |


### PR DESCRIPTION
- The adoption of Windows on ARM (WoA) devices is increasing, but many Python wheels remain unavailable for this platform.
- With GitHub now offering free WoA runners, we have the opportunity to add WoA support for cymem.
- This minimal patch introduce building and testing WoA cymem wheels