### PR TITLE
Add support for free-threaded build

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -14,6 +14,6 @@ jobs:
       contents: write
       actions: read
     with:
-      wheel-name-pattern: '*.whl'
+      wheel-name-pattern: 'cymem-*.whl'
     secrets:
       gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -7,6 +7,9 @@ on:
       # ** matches 'zero or more of any character'
       - 'release-v[0-9]+.[0-9]+.[0-9]+**'
       - 'prerelease-v[0-9]+.[0-9]+.[0-9]+**'
+  # TODO: Remove this before upstream PR
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -19,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@v3.2.1
         env:
           CIBW_SOME_OPTION: value
         with:
@@ -43,50 +46,52 @@ jobs:
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
-  create_release:
-    needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      checks: write
-      actions: read
-      issues: read
-      packages: write
-      pull-requests: read
-      repository-projects: read
-      statuses: read
-    steps:
-      - name: Get the tag name and determine if it's a prerelease
-        id: get_tag_info
-        run: |
-          FULL_TAG=${GITHUB_REF#refs/tags/}
-          if [[ $FULL_TAG == release-* ]]; then
-            TAG_NAME=${FULL_TAG#release-}
-            IS_PRERELEASE=false
-          elif [[ $FULL_TAG == prerelease-* ]]; then
-            TAG_NAME=${FULL_TAG#prerelease-}
-            IS_PRERELEASE=true
-          else
-            echo "Tag does not match expected patterns" >&2
-            exit 1
-          fi
-          echo "FULL_TAG=$TAG_NAME" >> $GITHUB_ENV
-          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
-          echo "IS_PRERELEASE=$IS_PRERELEASE" >> $GITHUB_ENV
-      - uses: actions/download-artifact@v4
-        with:
-          # unpacks all CIBW artifacts into dist/
-          pattern: cibw-*
-          path: dist
-          merge-multiple: true
-      - name: Create Draft Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          name: ${{ env.TAG_NAME }}
-          draft: true
-          prerelease: ${{ env.IS_PRERELEASE }}
-          files: "./dist/*" 
+
+  # TODO: Uncomment this before upstream PR
+  # create_release:
+  #   needs: [build_wheels, build_sdist]
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: write
+  #     checks: write
+  #     actions: read
+  #     issues: read
+  #     packages: write
+  #     pull-requests: read
+  #     repository-projects: read
+  #     statuses: read
+  #   steps:
+  #     - name: Get the tag name and determine if it's a prerelease
+  #       id: get_tag_info
+  #       run: |
+  #         FULL_TAG=${GITHUB_REF#refs/tags/}
+  #         if [[ $FULL_TAG == release-* ]]; then
+  #           TAG_NAME=${FULL_TAG#release-}
+  #           IS_PRERELEASE=false
+  #         elif [[ $FULL_TAG == prerelease-* ]]; then
+  #           TAG_NAME=${FULL_TAG#prerelease-}
+  #           IS_PRERELEASE=true
+  #         else
+  #           echo "Tag does not match expected patterns" >&2
+  #           exit 1
+  #         fi
+  #         echo "FULL_TAG=$TAG_NAME" >> $GITHUB_ENV
+  #         echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+  #         echo "IS_PRERELEASE=$IS_PRERELEASE" >> $GITHUB_ENV
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         # unpacks all CIBW artifacts into dist/
+  #         pattern: cibw-*
+  #         path: dist
+  #         merge-multiple: true
+  #     - name: Create Draft Release
+  #       id: create_release
+  #       uses: softprops/action-gh-release@v2
+  #       if: startsWith(github.ref, 'refs/tags/')
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         name: ${{ env.TAG_NAME }}
+  #         draft: true
+  #         prerelease: ${{ env.IS_PRERELEASE }}
+  #         files: "./dist/*" 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -14,6 +14,6 @@ jobs:
       contents: write
       actions: read
     with:
-      pure-python: false
+      wheel-name-pattern: '*.whl'
     secrets:
       gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -7,9 +7,6 @@ on:
       # ** matches 'zero or more of any character'
       - 'release-v[0-9]+.[0-9]+.[0-9]+**'
       - 'prerelease-v[0-9]+.[0-9]+.[0-9]+**'
-  # TODO: Remove this before upstream PR
-  pull_request:
-    types: [opened, synchronize, reopened, edited]
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -46,52 +43,50 @@ jobs:
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
-
-  # TODO: Uncomment this before upstream PR
-  # create_release:
-  #   needs: [build_wheels, build_sdist]
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: write
-  #     checks: write
-  #     actions: read
-  #     issues: read
-  #     packages: write
-  #     pull-requests: read
-  #     repository-projects: read
-  #     statuses: read
-  #   steps:
-  #     - name: Get the tag name and determine if it's a prerelease
-  #       id: get_tag_info
-  #       run: |
-  #         FULL_TAG=${GITHUB_REF#refs/tags/}
-  #         if [[ $FULL_TAG == release-* ]]; then
-  #           TAG_NAME=${FULL_TAG#release-}
-  #           IS_PRERELEASE=false
-  #         elif [[ $FULL_TAG == prerelease-* ]]; then
-  #           TAG_NAME=${FULL_TAG#prerelease-}
-  #           IS_PRERELEASE=true
-  #         else
-  #           echo "Tag does not match expected patterns" >&2
-  #           exit 1
-  #         fi
-  #         echo "FULL_TAG=$TAG_NAME" >> $GITHUB_ENV
-  #         echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
-  #         echo "IS_PRERELEASE=$IS_PRERELEASE" >> $GITHUB_ENV
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         # unpacks all CIBW artifacts into dist/
-  #         pattern: cibw-*
-  #         path: dist
-  #         merge-multiple: true
-  #     - name: Create Draft Release
-  #       id: create_release
-  #       uses: softprops/action-gh-release@v2
-  #       if: startsWith(github.ref, 'refs/tags/')
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         name: ${{ env.TAG_NAME }}
-  #         draft: true
-  #         prerelease: ${{ env.IS_PRERELEASE }}
-  #         files: "./dist/*" 
+  create_release:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
+      actions: read
+      issues: read
+      packages: write
+      pull-requests: read
+      repository-projects: read
+      statuses: read
+    steps:
+      - name: Get the tag name and determine if it's a prerelease
+        id: get_tag_info
+        run: |
+          FULL_TAG=${GITHUB_REF#refs/tags/}
+          if [[ $FULL_TAG == release-* ]]; then
+            TAG_NAME=${FULL_TAG#release-}
+            IS_PRERELEASE=false
+          elif [[ $FULL_TAG == prerelease-* ]]; then
+            TAG_NAME=${FULL_TAG#prerelease-}
+            IS_PRERELEASE=true
+          else
+            echo "Tag does not match expected patterns" >&2
+            exit 1
+          fi
+          echo "FULL_TAG=$TAG_NAME" >> $GITHUB_ENV
+          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+          echo "IS_PRERELEASE=$IS_PRERELEASE" >> $GITHUB_ENV
+      - uses: actions/download-artifact@v4
+        with:
+          # unpacks all CIBW artifacts into dist/
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+      - name: Create Draft Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: ${{ env.TAG_NAME }}
+          draft: true
+          prerelease: ${{ env.IS_PRERELEASE }}
+          files: "./dist/*" 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,8 @@ env:
 jobs:
   tests:
     name: Test
-    if: github.repository_owner == 'explosion'
+    # TODO: Uncomment this before upstream PR
+    # if: github.repository_owner == 'explosion'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,7 @@ env:
 jobs:
   tests:
     name: Test
-    # TODO: Uncomment this before upstream PR
-    # if: github.repository_owner == 'explosion'
+    if: github.repository_owner == 'explosion'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
         exclude:
           # The 3.9/3.10 arm64 Python binaries that `setup-python` tries to use
           # don't work on macOS 15 anymore, so skip those.

--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ free-threaded builds (PEP 703). All operations on the Pool, including `alloc()`,
     thread-safe.
 
 **Important notes:**
-- Individual `Pool` instances are thread-safe, but you are still responsible
-    for proper synchronization when accessing the memory contents themselves.
+- Individual Pool instances are thread-safe, but you are still responsible for
+    proper synchronization when accessing the memory contents themselves. Note
+    that holding a lock on the Pool itself is typically not the right approach:
+    since malloc is thread-safe, memory allocated by separate calls to `alloc`
+    can be safely accessed concurrently without locking. You should only
+    synchronize access to specific memory regions that are being shared across
+    threads, using fine-grained locks appropriate to your use case rather than a
+    coarse-grained lock on the entire `Pool`.
 - Custom memory allocators need to be thread-safe themselves.

--- a/README.md
+++ b/README.md
@@ -204,11 +204,13 @@ free-threaded builds (PEP 703). All operations on the Pool, including `alloc()`,
 
 **Key guarantees:**
 - Multiple threads can safely call `alloc()`, `free()`, and `realloc()` on the
-    same Pool instance
+    same `Pool` instance.
 - The Pool's internal bookkeeping (`addresses` dict and `size` accounting) is
-    protected from race conditions
+    protected from race conditions. Reading the internal state without
+    holding a lock on the `Pool` instance via a critical section is not
+    thread-safe.
 
 **Important notes:**
 - Individual `Pool` instances are thread-safe, but you are still responsible
-    for proper synchronization when accessing the memory contents themselves
+    for proper synchronization when accessing the memory contents themselves.
 - Custom memory allocators need to be thread-safe themselves.

--- a/README.md
+++ b/README.md
@@ -195,3 +195,20 @@ objects, but we'd still like the laziness of the `Pool`.
 from cymem.cymem cimport Pool, WrapMalloc, WrapFree
 cdef Pool mem = Pool(WrapMalloc(priv_malloc), WrapFree(priv_free))
 ```
+
+## Thread Safety
+
+As of version 2.0.12, `cymem.Pool` is thread-safe when used with CPython 3.13+
+free-threaded builds (PEP 703). All operations on the Pool, including `alloc()`,
+`free()`, and `realloc()`, can be safely called from multiple threads concurrently.
+
+**Key guarantees:**
+- Multiple threads can safely call `alloc()`, `free()`, and `realloc()` on the
+    same Pool instance
+- The Pool's internal bookkeeping (`addresses` dict and `size` accounting) is
+    protected from race conditions
+
+**Important notes:**
+- Individual `Pool` instances are thread-safe, but you are still responsible
+    for proper synchronization when accessing the memory contents themselves
+- Custom memory allocators need to be thread-safe themselves.

--- a/cymem/cymem.pyx
+++ b/cymem/cymem.pyx
@@ -141,7 +141,10 @@ cdef class Pool:
         # We need a critical section on both self and self.addresses here.
         # See comment in alloc for rationale.
         with cython.critical_section(self, self.addresses):
-            self.size -= self.addresses.pop(<size_t>p)
+            # The cast to size_t below is needed so that Cython
+            # does not call into the C API to do the subtraction,
+            # which could potentially release the critical section.
+            self.size -= <size_t>self.addresses.pop(<size_t>p)
         self.pyfree.free(p)
 
     def own_pyref(self, object py_ref):

--- a/cymem/cymem.pyx
+++ b/cymem/cymem.pyx
@@ -117,7 +117,7 @@ cdef class Pool:
                 self.pyfree.free(new_ptr)
                 raise ValueError("Pointer %d not found in Pool %s" % (<size_t>p, self.addresses))
 
-            if new_size <= old_size:
+            if old_size >= new_size:
                 self.pyfree.free(new_ptr)
                 self.addresses[<size_t>p] = old_size
                 raise ValueError("Realloc requires new_size > previous size")

--- a/cymem/cymem.pyx
+++ b/cymem/cymem.pyx
@@ -143,10 +143,13 @@ cdef class Pool:
 
         If p is not in Pool.addresses, a KeyError is raised.
         """
+        cdef size_t size
+
         # See comment in alloc on why we're acquiring a critical section on
         # self.addresses instead of self.
         with cython.critical_section(self.addresses):
-            self.size -= <size_t>self.addresses.pop(<size_t>p)
+            size = self.addresses.pop(<size_t>p)
+            self.size -= size
         self.pyfree.free(p)
 
     def own_pyref(self, object py_ref):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools",
-    "cython>=0.25",
+    "cython>=3.1",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 build = "*"
 skip = "pp* cp36* cp37* cp38*"
 test-skip = ""
-free-threaded-support = false
+enable = ["cpython-freethreading"]
 
 archs = ["native"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-cython>=0.25
+cython>=3.1
 pytest

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,7 @@ def setup_package():
                 "Programming Language :: Python :: 3.12",
                 "Programming Language :: Python :: 3.13",
                 "Programming Language :: Python :: 3.14",
+                "Programming Language :: Python :: Free Threading :: 2 - Beta",
                 "Topic :: Scientific/Engineering",
             ],
             cmdclass={"build_ext": build_ext_subclass},

--- a/setup.py
+++ b/setup.py
@@ -100,8 +100,8 @@ def setup_package():
             version=about["__version__"],
             url=about["__uri__"],
             license=about["__license__"],
-            ext_modules=cythonize(ext_modules, language_level=2),
-            setup_requires=["cython>=0.25"],
+            ext_modules=cythonize(ext_modules),
+            setup_requires=["cython>=3.1"],
             classifiers=[
                 "Environment :: Console",
                 "Intended Audience :: Developers",
@@ -116,6 +116,7 @@ def setup_package():
                 "Programming Language :: Python :: 3.11",
                 "Programming Language :: Python :: 3.12",
                 "Programming Language :: Python :: 3.13",
+                "Programming Language :: Python :: 3.14",
                 "Topic :: Scientific/Engineering",
             ],
             cmdclass={"build_ext": build_ext_subclass},


### PR DESCRIPTION
Add support for Python 3.13+ free-threaded builds. The `cymem.Pool` class is now thread-safe, allowing concurrent memory operations from multiple threads without external locking.

Major changes:

- Thread-safe Pool implementation: Protected Pool internal state (addresses dict and size accounting) using Cython's critical sections to prevent race conditions
- Improved realloc() method: Refactored to ensure thread-safety
- Cython 3.1+ requirement: Upgraded minimum Cython version to support free-threading features
- Documentation: Added thread-safety documentation to README explaining guarantees and best practices